### PR TITLE
Replace python multiprocessing with Numba parallel (and other comments)

### DIFF
--- a/idg/python/idg.py
+++ b/idg/python/idg.py
@@ -2,40 +2,7 @@ import numpy as np
 import numba as nb
 
 import idgtypes
-from kernels import add_subgrid_to_grid, compute_phasor, visibilities_to_subgrid
-
-
-@nb.njit(parallel=True)
-def grid_into_subgrids(
-    w_step,
-    image_size,
-    grid_size,
-    wavenumbers,
-    uvw,
-    visibilities,
-    taper,
-    metadata,
-    subgrids,
-):
-    nr_subgrids = metadata.shape[0]
-
-    # Grid visibilities onto subgrids
-    for s in nb.prange(nr_subgrids):
-        visibilities_to_subgrid(
-            s,
-            metadata,
-            w_step,
-            grid_size,
-            image_size,
-            wavenumbers,
-            visibilities,
-            uvw,
-            taper,
-            visibilities.shape[3],
-            subgrids.shape[2],
-            subgrids[s],
-        )
-    return subgrids
+from kernels import add_subgrid_to_grid, compute_phasor, visibilities_to_subgrids
 
 
 class Gridder:
@@ -74,7 +41,7 @@ class Gridder:
         assert self.nr_correlations_out == subgrids.shape[1]
         assert self.subgrid_size == subgrids.shape[2]
 
-        subgrids = grid_into_subgrids(
+        visibilities_to_subgrids(
             w_step,
             image_size,
             grid_size,

--- a/idg/python/idg.py
+++ b/idg/python/idg.py
@@ -1,16 +1,26 @@
 import numpy as np
-from numba import njit, prange
+import numba as nb
 
 import idgtypes
 from kernels import add_subgrid_to_grid, compute_phasor, visibilities_to_subgrid
 
 
-@njit(parallel=True)
-def grid_into_subgrids(w_step, image_size, grid_size, wavenumbers, uvw, visibilities, taper, metadata, subgrids):
+@nb.njit(parallel=True)
+def grid_into_subgrids(
+    w_step,
+    image_size,
+    grid_size,
+    wavenumbers,
+    uvw,
+    visibilities,
+    taper,
+    metadata,
+    subgrids,
+):
     nr_subgrids = metadata.shape[0]
 
     # Grid visibilities onto subgrids
-    for s in prange(nr_subgrids):
+    for s in nb.prange(nr_subgrids):
         visibilities_to_subgrid(
             s,
             metadata,
@@ -64,11 +74,20 @@ class Gridder:
         assert self.nr_correlations_out == subgrids.shape[1]
         assert self.subgrid_size == subgrids.shape[2]
 
-        subgrids = grid_into_subgrids(w_step, image_size, grid_size, wavenumbers, uvw, visibilities, taper, metadata, subgrids)
+        subgrids = grid_into_subgrids(
+            w_step,
+            image_size,
+            grid_size,
+            wavenumbers,
+            uvw,
+            visibilities,
+            taper,
+            metadata,
+            subgrids,
+        )
 
         # Apply FFT to each subgrid
         subgrids[:] = np.fft.ifft2(subgrids, axes=(2, 3))
-
 
     def add_subgrids_to_grid(
         self,

--- a/idg/python/idg.py
+++ b/idg/python/idg.py
@@ -1,9 +1,31 @@
-from concurrent.futures import ThreadPoolExecutor, as_completed
-import multiprocessing
 import numpy as np
+from numba import njit, prange
 
 import idgtypes
 from kernels import add_subgrid_to_grid, compute_phasor, visibilities_to_subgrid
+
+
+@njit(parallel=True)
+def grid_into_subgrids(w_step, image_size, grid_size, wavenumbers, uvw, visibilities, taper, metadata, subgrids):
+    nr_subgrids = metadata.shape[0]
+
+    # Grid visibilities onto subgrids
+    for s in prange(nr_subgrids):
+        visibilities_to_subgrid(
+            s,
+            metadata,
+            w_step,
+            grid_size,
+            image_size,
+            wavenumbers,
+            visibilities,
+            uvw,
+            taper,
+            visibilities.shape[3],
+            subgrids.shape[2],
+            subgrids[s],
+        )
+    return subgrids
 
 
 class Gridder:
@@ -41,34 +63,12 @@ class Gridder:
         assert self.nr_correlations_in == visibilities.shape[3]
         assert self.nr_correlations_out == subgrids.shape[1]
         assert self.subgrid_size == subgrids.shape[2]
-        nr_subgrids = metadata.shape[0]
 
-        # Grid visibilities onto subgrids
-        with ThreadPoolExecutor(max_workers=multiprocessing.cpu_count()) as executor:
-            futures = []
-            for s in range(nr_subgrids):
-                future = executor.submit(
-                    visibilities_to_subgrid,
-                    s,
-                    metadata,
-                    w_step,
-                    grid_size,
-                    image_size,
-                    wavenumbers,
-                    visibilities,
-                    uvw,
-                    taper,
-                    self.nr_correlations_in,
-                    self.subgrid_size,
-                    subgrids[s],
-                )
-                futures.append(future)
-
-            for future in as_completed(futures):
-                pass
+        subgrids = grid_into_subgrids(w_step, image_size, grid_size, wavenumbers, uvw, visibilities, taper, metadata, subgrids)
 
         # Apply FFT to each subgrid
         subgrids[:] = np.fft.ifft2(subgrids, axes=(2, 3))
+
 
     def add_subgrids_to_grid(
         self,

--- a/idg/python/init.py
+++ b/idg/python/init.py
@@ -1,7 +1,6 @@
-from concurrent.futures import ThreadPoolExecutor, as_completed
-import multiprocessing
 import random
 import numpy as np
+import numba as nb
 
 import idgtypes
 
@@ -142,6 +141,7 @@ def get_metadata(
     return np.asarray(metadata)
 
 
+@nb.njit(cache=True, nogil=True, parallel=True)
 def get_visibilities(
     nr_correlations: int,
     nr_channels: int,
@@ -198,25 +198,18 @@ def get_visibilities(
         l = offset[0] * image_size / grid_size
         m = offset[1] * image_size / grid_size
 
-        with ThreadPoolExecutor(max_workers=multiprocessing.cpu_count()) as executor:
-            futures = []
-            for bl in range(nr_baselines):
-                future = executor.submit(
-                    add_pt_src_to_baseline,
-                    bl,
-                    nr_timesteps,
-                    nr_channels,
-                    amplitude,
-                    frequencies,
-                    uvw,
-                    l,
-                    m,
-                    visibilities,
-                )
-                futures.append(future)
-
-            for future in as_completed(futures):
-                pass
+        for bl in nb.prange(nr_baselines):
+            add_pt_src_to_baseline(
+                bl,
+                nr_timesteps,
+                nr_channels,
+                amplitude,
+                frequencies,
+                uvw,
+                l,
+                m,
+                visibilities,
+            )
 
     return visibilities
 

--- a/idg/python/init.py
+++ b/idg/python/init.py
@@ -141,7 +141,7 @@ def get_metadata(
     return np.asarray(metadata)
 
 
-@nb.njit(cache=True, nogil=True, parallel=True)
+@nb.njit(cache=True, parallel=True)
 def get_visibilities(
     nr_correlations: int,
     nr_channels: int,

--- a/idg/python/kernels.py
+++ b/idg/python/kernels.py
@@ -163,7 +163,7 @@ def compute_n(l: float, m: float) -> float:
 
     return tmp / (1.0 + np.sqrt(1.0 - tmp))
 
-@nb.njit(cache=True, nogil=True, parallel=True)
+@nb.njit(cache=True, nogil=True)
 def visibilities_to_subgrid(
     s: int,
     metadata: dict,
@@ -215,8 +215,8 @@ def visibilities_to_subgrid(
     )
     w_offset = 2 * np.pi * w_offset_in_lambda
 
-    for y in nb.prange(subgrid_size):
-        for x in nb.prange(subgrid_size):
+    for y in range(subgrid_size):
+        for x in range(subgrid_size):
             # Compute l, m, n
             l = compute_l(x, subgrid_size, image_size)
             m = compute_m(y, subgrid_size, image_size)

--- a/idg/python/kernels.py
+++ b/idg/python/kernels.py
@@ -2,7 +2,7 @@ import numpy as np
 import numba as nb
 
 
-@nb.njit(fastmath=True, cache=True)
+@nb.njit(fastmath=True)
 def polyval(coefficients: np.ndarray, x: np.ndarray) -> np.ndarray:
     """
     Numba-compatible polynomial evaluation (equivalent to np.polyval).
@@ -20,7 +20,7 @@ def polyval(coefficients: np.ndarray, x: np.ndarray) -> np.ndarray:
     return result
 
 
-@nb.njit(fastmath=True, cache=False)
+@nb.njit(fastmath=True)
 def evaluate_spheroidal(nu: np.ndarray) -> np.ndarray:
     """
     Evaluate the prolate spheroidal wave function.
@@ -67,7 +67,7 @@ def evaluate_spheroidal(nu: np.ndarray) -> np.ndarray:
     return result
 
 
-@nb.njit(fastmath=True, cache=True, parallel=True)
+@nb.njit(fastmath=True, parallel=True)
 def add_pt_src_to_baseline(
     bl: int,  # baseline index
     nr_time: int,  # number of timesteps
@@ -297,7 +297,7 @@ def visibilities_to_subgrids(
     return subgrids
 
 
-@nb.njit(fastmath=True, cache=True)
+@nb.njit(fastmath=True)
 def compute_phasor(subgrid_size: int) -> np.ndarray:
     """
     Compute the phasor which is used to shift the subgrid to the correct position
@@ -314,7 +314,7 @@ def compute_phasor(subgrid_size: int) -> np.ndarray:
     return phasor
 
 
-@nb.njit(fastmath=True, cache=True)
+@nb.njit(fastmath=True)
 def add_subgrid_to_grid(
     s: int,
     metadata: np.ndarray,
@@ -365,7 +365,7 @@ def add_subgrid_to_grid(
                     )
 
 
-@nb.njit(fastmath=True, cache=True)
+@nb.njit(fastmath=True)
 def compute_metadata(
     grid_size: int,
     subgrid_size: int,

--- a/idg/python/kernels.py
+++ b/idg/python/kernels.py
@@ -67,7 +67,7 @@ def evaluate_spheroidal(nu: np.ndarray) -> np.ndarray:
     return result
 
 
-@nb.njit(fastmath=True, cache=True, nogil=True)
+@nb.njit(fastmath=True, cache=True, nogil=True, parallel=True)
 def add_pt_src_to_baseline(
     bl: int,  # baseline index
     nr_time: int,  # number of timesteps

--- a/idg/python/kernels.py
+++ b/idg/python/kernels.py
@@ -67,7 +67,7 @@ def evaluate_spheroidal(nu: np.ndarray) -> np.ndarray:
     return result
 
 
-@nb.njit(fastmath=True, cache=True, nogil=True, parallel=True)
+@nb.njit(fastmath=True, cache=True, parallel=True)
 def add_pt_src_to_baseline(
     bl: int,  # baseline index
     nr_time: int,  # number of timesteps
@@ -105,7 +105,7 @@ def add_pt_src_to_baseline(
             visibilities[bl, t, c, :] += value
 
 
-@nb.njit(fastmath=True, nogil=True)
+@nb.njit(fastmath=True)
 def compute_pixels(
     nr_correlations_out,
     nr_timesteps,
@@ -163,7 +163,7 @@ def compute_n(l: float, m: float) -> float:
 
     return tmp / (1.0 + np.sqrt(1.0 - tmp))
 
-@nb.njit(cache=True, nogil=True)
+@nb.njit(cache=True)
 def visibilities_to_subgrid(
     s: int,
     metadata: dict,

--- a/idg/python/kernels.py
+++ b/idg/python/kernels.py
@@ -165,7 +165,6 @@ def compute_n(l: float, m: float) -> float:
 
 @nb.njit(cache=True)
 def visibilities_to_subgrid(
-    s: int,
     metadata: dict,
     w_step: float,
     grid_size: int,
@@ -181,7 +180,6 @@ def visibilities_to_subgrid(
     """
     Grid visibilities onto a subgrid.
 
-    :param s: subgrid index
     :param metadata: metadata for the subgrid
     :param w_step: w step in wavelengths
     :param grid_size: grid size in pixels
@@ -195,7 +193,7 @@ def visibilities_to_subgrid(
     :param subgrid: subgrid array
     """
     # Load metadata
-    m = metadata[s]
+    m = metadata
     bl = m["baseline"]
     offset = m["time_index"]
     nr_timesteps = m["nr_timesteps"]
@@ -281,8 +279,7 @@ def visibilities_to_subgrids(
     # Grid visibilities onto subgrids
     for s in nb.prange(nr_subgrids):
         visibilities_to_subgrid(
-            s,
-            metadata,
+            metadata[s],
             w_step,
             grid_size,
             image_size,


### PR DESCRIPTION
I was asked bij @bhaaksema to take a look at the python implementation to see if I found obvious ways to improve it.

My main comment is that I would avoid using python multiprocessing and instead use the builtin parallelization of Numba. My main reasons are that it has lower memory and communication overhead since Numba uses proper threading instead of independent processes, and it offers much more flexibility for parallelizing nested for loops.

I made a POC change in this PR. I avoided refactoring which is needed to make the function arguments more clean. In practice this change does not really affect runtime though since the multiprocessing approach already makes 100% use of my CPU cores and that is currently the bottleneck.

I don't understand the actual algorithm, but I assume the most actual improvement would be gained by avoiding the very deep nested loops. I previously made a comparison between Numba and [Mojo](https://www.modular.com/mojo) and found that Numba was essentially equally performant to Mojo when the implementations were equivalent. A lot of performance is gained if a for loop can be replaced by matrix/array operations.

The primary bottleneck is that the `Gridder.grid_onto_subgrids` method is 6 nested loops deep and the inner loop is called 89653248000 times. When I comment out the [most inner operation](idg/python/kernels.py#l126) that is called so many times, the runtime of the gridder decreases from 94 seconds (on my machine) to less than 1 second. Therefore, the implementation could be a lot faster if it is possible to use some matrix operations.