### PR TITLE
[idg-python] Refactor the main program

### DIFF
--- a/idg/python/main.py
+++ b/idg/python/main.py
@@ -93,10 +93,7 @@ def timeit(description, operation):
     result = operation()
     end = time.time()
     duration = end - start
-    if duration > 1:
-        print(f" {duration:>9.3f} s")
-    else:
-        print(f" {duration*1e3:>8.3f} ms")
+    print(f" {duration:>9.6f} s")
     timings[description] = duration
     return result
 
@@ -197,8 +194,8 @@ print_header("TIMINGS")
 total_time = sum(timings.values())
 for operation, duration in timings.items():
     percentage = (duration / total_time) * 100
-    print(f"{operation:<30} {duration:>8.2f} s ({percentage:>5.1f}%)")
-print(f"{'Total':<30} {total_time:>8.2f} s")
+    print(f"{operation:<30} {duration:>8.3f} s ({percentage:>5.1f}%)")
+print(f"{'Total':<30} {total_time:>8.3f} s")
 
 if STORE_DATA:
     np.save("uvw.npy", uvw)


### PR DESCRIPTION
The main program still performs the same computation as before, but has been refactored significantly.

It now uses `argparse` to let the user specify what settings to use. For now, only the most common settings are exposed. When we move to reusing `.npy` files, we could add an option to read from a data directory instead of generating new input data.

The way that timings and output are handled is also completely changed. Helper functions deduplicate the code and arguably lead to cleaner output, e.g.:
```
==================================================
PARAMETERS
==================================================
nr_correlations_in                               2
nr_correlations_out                              1
start_frequency                              150.0
frequency_increment                            1.0
nr_channels                                     16
nr_timesteps                                 14400
nr_stations                                     20
nr_baselines                                   190
subgrid_size                                    32
grid_size                                     1024

==================================================
INITIALIZATION
==================================================
Initialize UVW coordinates              0.047607 s
Initialize frequencies                  0.000009 s
Initialize metadata                     0.116819 s
Initialize visibilities                 0.202755 s
Initialize taper                        1.589489 s
Initialize gridder                      0.000004 s

==================================================
MAIN
==================================================
Grid visibilities                      10.462054 s
Add subgrids                            0.055364 s
Transform grid                          0.009178 s

==================================================
TIMINGS
==================================================
Initialize UVW coordinates        0.048 s (  0.4%)
Initialize frequencies            0.000 s (  0.0%)
Initialize metadata               0.117 s (  0.9%)
Initialize visibilities           0.203 s (  1.6%)
Initialize taper                  1.589 s ( 12.7%)
Initialize gridder                0.000 s (  0.0%)
Grid visibilities                10.462 s ( 83.8%)
Add subgrids                      0.055 s (  0.4%)
Transform grid                    0.009 s (  0.1%)
Total                            12.483 s
```

To prepare for Bencher, there is also an option to write a `.json` file.