### PR TITLE
idg: Correctness and speed fixes

### DIFF
--- a/idg/cpp/include/IDG.h
+++ b/idg/cpp/include/IDG.h
@@ -20,8 +20,7 @@ public:
                           const xt::xarray<Metadata> &metadata,
                           xt::xarray<std::complex<float>> &subgrids) const;
 
-  void ifft_subgrids(const xt::xarray<Metadata> &metadata,
-                     xt::xarray<std::complex<float>> &subgrids) const;
+  void ifft_subgrids(xt::xarray<std::complex<float>> &subgrids) const;
 
   void add_subgrids_to_grid(const xt::xarray<Metadata> &metadata,
                             const xt::xarray<std::complex<float>> &subgrids,

--- a/idg/cpp/include/IDG.h
+++ b/idg/cpp/include/IDG.h
@@ -1,6 +1,5 @@
 #include <complex>
 #include <cstddef>
-#include <vector>
 
 #include <xtensor/containers/xarray.hpp>
 
@@ -20,6 +19,9 @@ public:
                           const xt::xarray<float> &taper,
                           const xt::xarray<Metadata> &metadata,
                           xt::xarray<std::complex<float>> &subgrids) const;
+
+  void ifft_subgrids(const xt::xarray<Metadata> &metadata,
+                     xt::xarray<std::complex<float>> &subgrids) const;
 
   void add_subgrids_to_grid(const xt::xarray<Metadata> &metadata,
                             const xt::xarray<std::complex<float>> &subgrids,

--- a/idg/cpp/include/IDG.h
+++ b/idg/cpp/include/IDG.h
@@ -26,7 +26,7 @@ public:
                             const xt::xarray<std::complex<float>> &subgrids,
                             xt::xarray<std::complex<float>> &grid) const;
 
-  void transform(int direction, xt::xarray<std::complex<float>> &grid) const;
+  void transform(xt::xarray<std::complex<float>> &grid) const;
 
 private:
   size_t nr_correlations_in_;

--- a/idg/cpp/include/idgtypes-io.h
+++ b/idg/cpp/include/idgtypes-io.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "idgtypes.h"
 #include <fstream>
 #include <xtensor/containers/xarray.hpp>
 #include <xtensor/io/xnpy.hpp>

--- a/idg/cpp/include/idgtypes-io.h
+++ b/idg/cpp/include/idgtypes-io.h
@@ -1,96 +1,37 @@
 #pragma once
 
 #include "idgtypes.h"
-#include <fstream>
+#include "npy-parser.h"
+#include <string_view>
 #include <xtensor/containers/xarray.hpp>
-#include <xtensor/io/xnpy.hpp>
+
+namespace idgtypes_io {
+inline constexpr std::string_view uvw_dtype_descr =
+    "[('u','<f4'),('v','<f4'),('w','<f4')]";
+inline constexpr std::string_view metadata_dtype_descr =
+    "[('baseline','<i4'),('time_index','<i4'),('nr_timesteps','<i4'),"
+    "('channel_begin','<i4'),('channel_end','<i4'),('coordinate',[('x',"
+    "'<i4'),('y','<i4'),('z','<i4')])]";
+} // namespace idgtypes_io
+
+namespace npy_parser {
+inline xt::xarray<UVW> load_npy_uvw(const std::string &filename) {
+  return load_npy_array<UVW>(filename, idgtypes_io::uvw_dtype_descr);
+}
+
+inline xt::xarray<Metadata> load_npy_metadata(const std::string &filename) {
+  return load_npy_array<Metadata>(filename, idgtypes_io::metadata_dtype_descr);
+}
+} // namespace npy_parser
 
 namespace xt {
 inline void dump_npy(const std::string &filename, const xt::xarray<UVW> &arr) {
-  std::ofstream file(filename, std::ios::binary);
-  if (!file) {
-    throw std::runtime_error("Cannot open file: " + filename);
-  }
-
-  // NPY magic
-  char magic[6] = {'\x93', 'N', 'U', 'M', 'P', 'Y'};
-  file.write(magic, 6);
-
-  // Version 1.0
-  char version[2] = {1, 0};
-  file.write(version, 2);
-
-  // Structured dtype
-  std::string dtype = "[('u', '<f4'), ('v', '<f4'), ('w', '<f4')]";
-
-  // Build shape string
-  std::string shape_str = "(";
-  for (size_t i = 0; i < arr.shape().size(); ++i) {
-    if (i > 0)
-      shape_str += ", ";
-    shape_str += std::to_string(arr.shape()[i]);
-  }
-  shape_str += ",)";
-
-  std::string header = "{'descr': " + dtype +
-                       ", 'fortran_order': False, 'shape': " + shape_str +
-                       ", }";
-
-  // Pad to 64-byte boundary
-  size_t header_len = header.size() + 1;
-  size_t padding = (64 - ((10 + header_len) % 64)) % 64;
-  header.append(padding, ' ');
-  header += '\n';
-
-  uint16_t header_len_le = static_cast<uint16_t>(header.size());
-  file.write(reinterpret_cast<char *>(&header_len_le), 2);
-  file.write(header.data(), header.size());
-
-  file.write(reinterpret_cast<const char *>(arr.data()),
-             arr.size() * sizeof(UVW));
+  npy_parser::dump_npy_array(filename, arr, idgtypes_io::uvw_dtype_descr);
 }
 
 inline void dump_npy(const std::string &filename,
                      const xt::xarray<Metadata> &arr) {
-  std::ofstream file(filename, std::ios::binary);
-  if (!file) {
-    throw std::runtime_error("Cannot open file: " + filename);
-  }
-
-  // NPY magic
-  char magic[6] = {'\x93', 'N', 'U', 'M', 'P', 'Y'};
-  file.write(magic, 6);
-
-  // Version 1.0
-  char version[2] = {1, 0};
-  file.write(version, 2);
-
-  // Structured dtype
-  std::string dtype =
-      "[('baseline', '<i4'), ('time_index', '<i4'), "
-      "('nr_timesteps', '<i4'), ('channel_begin', '<i4'), "
-      "('channel_end', '<i4'), "
-      "('coordinate', [('x', '<i4'), ('y', '<i4'), ('z', '<i4')])]";
-
-  std::string shape_str = "(" + std::to_string(arr.size()) + ",)";
-
-  std::string header = "{'descr': " + dtype +
-                       ", 'fortran_order': False, 'shape': " + shape_str +
-                       ", }";
-
-  // Pad to 64-byte boundary
-  size_t header_len = header.size() + 1;
-  size_t padding = (64 - ((10 + header_len) % 64)) % 64;
-  header.append(padding, ' ');
-  header += '\n';
-
-  uint16_t header_len_le = static_cast<uint16_t>(header.size());
-  file.write(reinterpret_cast<char *>(&header_len_le), 2);
-  file.write(header.data(), header.size());
-
-  // Write data
-  file.write(reinterpret_cast<const char *>(arr.data()),
-             arr.size() * sizeof(Metadata));
+  npy_parser::dump_npy_array(filename, arr, idgtypes_io::metadata_dtype_descr);
 }
 
 } // namespace xt

--- a/idg/cpp/include/idgtypes.h
+++ b/idg/cpp/include/idgtypes.h
@@ -27,5 +27,7 @@ struct Metadata {
   Coordinate coordinate;
 };
 
+#pragma pack(pop)
+
 constexpr int FourierDomainToImageDomain = 0;
 constexpr int ImageDomainToFourierDomain = 1;

--- a/idg/cpp/include/npy-parser.h
+++ b/idg/cpp/include/npy-parser.h
@@ -1,5 +1,16 @@
-#include "idgtypes.h"
+#pragma once
+
+#include <cstddef>
+#include <fstream>
+#include <istream>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <xtensor/containers/xadapt.hpp>
 #include <xtensor/containers/xarray.hpp>
+#include <xtensor/core/xlayout.hpp>
 // Complete reimplementation of the reading parts of xnpy.hpp that supports our
 // custom types. It is unfortunately necessary to do this because their code is
 // not suitable for reuse.
@@ -8,16 +19,67 @@
 // https://github.com/xtensor-stack/xtensor/blob/master/include/xtensor/io/xnpy.hpp
 
 namespace npy_parser {
-xt::xarray<UVW> load_npy_uvw(const std::string &filename);
-xt::xarray<Metadata> load_npy_metadata(const std::string &filename);
-inline void read_magic(std::istream &istream, unsigned char *v_major,
-                       unsigned char *v_minor);
-inline std::string read_header_1_0(std::istream &istream);
-inline std::string read_header_2_0(std::istream &istream);
-inline void parse_header(std::string header, std::string &descr,
-                         bool *fortran_order, std::vector<std::size_t> &shape);
-inline std::string unwrap_s(std::string s, char delim_front, char delim_back);
-inline std::string get_value_from_map(std::string mapstr);
-inline void pop_char(std::string &s, char c);
+struct npy_header {
+  std::string descr;
+  bool fortran_order;
+  std::vector<std::size_t> shape;
+};
+
+npy_header load_npy_header(const std::string &filename);
+npy_header load_npy_header(std::istream &istream);
+void write_npy_header(std::ostream &ostream, std::string_view descr,
+                      const std::vector<std::size_t> &shape,
+                      bool fortran_order);
+
+template <typename T>
+xt::xarray<T> load_npy_array(const std::string &filename,
+                             std::string_view expected_descr) {
+  std::ifstream stream(filename, std::ifstream::binary);
+  if (!stream) {
+    XTENSOR_THROW(std::runtime_error, "io error: failed to open a file.");
+  }
+
+  npy_header header = load_npy_header(stream);
+  if (header.descr != expected_descr) {
+    XTENSOR_THROW(std::runtime_error, "type does not match expected layout.");
+  }
+
+  const std::size_t item_count = xt::compute_size(header.shape);
+  std::vector<T> buffer(item_count);
+  stream.read(reinterpret_cast<char *>(buffer.data()),
+              std::streamsize(item_count * sizeof(T)));
+  if (!stream) {
+    XTENSOR_THROW(std::runtime_error, "io error: failed reading array data.");
+  }
+
+  const auto layout = header.fortran_order ? xt::layout_type::column_major
+                                           : xt::layout_type::row_major;
+  xt::xarray<T> output = xt::adapt(std::move(buffer), header.shape, layout);
+  return output;
+}
+
+template <typename T>
+void dump_npy_array(const std::string &filename, const xt::xarray<T> &arr,
+                    std::string_view descr) {
+  std::ofstream file(filename, std::ios::binary);
+  if (!file) {
+    throw std::runtime_error("Cannot open file: " + filename);
+  }
+
+  std::vector<std::size_t> shape(arr.shape().begin(), arr.shape().end());
+  write_npy_header(file, descr, shape, false);
+  file.write(reinterpret_cast<const char *>(arr.data()),
+             std::streamsize(arr.size() * sizeof(T)));
+}
+
+inline xt::xarray<char> load_npy_raw(const std::string &filename,
+                                     std::string_view expected_descr) {
+  return load_npy_array<char>(filename, expected_descr);
+}
+
+inline void dump_npy_raw(const std::string &filename,
+                         const xt::xarray<char> &arr, std::string_view descr) {
+  dump_npy_array<char>(filename, arr, descr);
+}
 
 } // namespace npy_parser

--- a/idg/cpp/include/npy-parser.h
+++ b/idg/cpp/include/npy-parser.h
@@ -1,0 +1,23 @@
+#include "idgtypes.h"
+#include <xtensor/containers/xarray.hpp>
+// Complete reimplementation of the reading parts of xnpy.hpp that supports our
+// custom types. It is unfortunately necessary to do this because their code is
+// not suitable for reuse.
+
+// Derived from
+// https://github.com/xtensor-stack/xtensor/blob/master/include/xtensor/io/xnpy.hpp
+
+namespace npy_parser {
+xt::xarray<UVW> load_npy_uvw(const std::string &filename);
+xt::xarray<Metadata> load_npy_metadata(const std::string &filename);
+inline void read_magic(std::istream &istream, unsigned char *v_major,
+                       unsigned char *v_minor);
+inline std::string read_header_1_0(std::istream &istream);
+inline std::string read_header_2_0(std::istream &istream);
+inline void parse_header(std::string header, std::string &descr,
+                         bool *fortran_order, std::vector<std::size_t> &shape);
+inline std::string unwrap_s(std::string s, char delim_front, char delim_back);
+inline std::string get_value_from_map(std::string mapstr);
+inline void pop_char(std::string &s, char c);
+
+} // namespace npy_parser

--- a/idg/cpp/src/CMakeLists.txt
+++ b/idg/cpp/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories("${CMAKE_SOURCE_DIR}/include")
 
-add_library(idg OBJECT IDG.cpp init.cpp kernels.cpp)
+add_library(idg OBJECT IDG.cpp init.cpp kernels.cpp npy-parser.cpp)
 target_link_libraries(idg PUBLIC cxxopts xtensor xtensor-fftw PkgConfig::FFTW
                                  OpenMP::OpenMP_CXX)
 

--- a/idg/cpp/src/IDG.cpp
+++ b/idg/cpp/src/IDG.cpp
@@ -36,17 +36,17 @@ void Gridder::grid_onto_subgrids(
   }
 }
 
-void Gridder::ifft_subgrids(const xt::xarray<Metadata> &metadata,
-                            xt::xarray<std::complex<float>> &subgrids) const {
-  const size_t nr_subgrids = metadata.size();
+void Gridder::ifft_subgrids(xt::xarray<std::complex<float>> &subgrids) const {
+  for (size_t s = 0; s < subgrids.shape(0); ++s) {
+    for (size_t c = 0; c < subgrids.shape(1); ++s) {
+      auto subgrid = xt::eval(xt::view(subgrids, s, c, xt::all(), xt::all()));
 
-  for (size_t s = 0; s < nr_subgrids; ++s) {
-    auto subgrid =
-        xt::eval(xt::view(subgrids, s, xt::all(), xt::all(), xt::all()));
+      subgrid = xt::fftw::ifft2(subgrid);
 
-    subgrid = xt::fftw::ifft2(subgrid);
+      subgrid = subgrid / (subgrid_size_ * subgrid_size_);
 
-    xt::view(subgrids, s, xt::all(), xt::all(), xt::all()) = subgrid;
+      xt::view(subgrids, s, xt::all(), xt::all(), xt::all()) = subgrid;
+    }
   }
 }
 

--- a/idg/cpp/src/IDG.cpp
+++ b/idg/cpp/src/IDG.cpp
@@ -23,7 +23,7 @@ void Gridder::grid_onto_subgrids(
   assert(subgrid_size_ == subgrids.shape()[2]);
   const size_t nr_subgrids = metadata.size();
 
-#pragma omp parallel for schedule(dynamic)
+  // #pragma omp parallel for schedule(dynamic)
   for (size_t s = 0; s < nr_subgrids; ++s) {
     auto subgrid =
         xt::eval(xt::view(subgrids, s, xt::all(), xt::all(), xt::all()));
@@ -38,14 +38,14 @@ void Gridder::grid_onto_subgrids(
 
 void Gridder::ifft_subgrids(xt::xarray<std::complex<float>> &subgrids) const {
   for (size_t s = 0; s < subgrids.shape(0); ++s) {
-    for (size_t c = 0; c < subgrids.shape(1); ++s) {
+    for (size_t c = 0; c < subgrids.shape(1); ++c) {
       auto subgrid = xt::eval(xt::view(subgrids, s, c, xt::all(), xt::all()));
 
       subgrid = xt::fftw::ifft2(subgrid);
 
       subgrid = subgrid / (subgrid_size_ * subgrid_size_);
 
-      xt::view(subgrids, s, xt::all(), xt::all(), xt::all()) = subgrid;
+      xt::view(subgrids, s, c, xt::all(), xt::all()) = subgrid;
     }
   }
 }

--- a/idg/cpp/src/IDG.cpp
+++ b/idg/cpp/src/IDG.cpp
@@ -1,6 +1,5 @@
 #include <complex>
 #include <cstddef>
-#include <vector>
 
 #include <omp.h>
 
@@ -32,6 +31,20 @@ void Gridder::grid_onto_subgrids(
     visibilities_to_subgrid(s, metadata, w_step, grid_size, image_size,
                             wavenumbers, visibilities, uvw, taper,
                             nr_correlations_in_, subgrid_size_, subgrid);
+
+    subgrid = xt::fftw::ifft2(subgrid);
+
+    xt::view(subgrids, s, xt::all(), xt::all(), xt::all()) = subgrid;
+  }
+}
+
+void Gridder::ifft_subgrids(const xt::xarray<Metadata> &metadata,
+                            xt::xarray<std::complex<float>> &subgrids) const {
+  const size_t nr_subgrids = metadata.size();
+
+  for (size_t s = 0; s < nr_subgrids; ++s) {
+    auto subgrid =
+        xt::eval(xt::view(subgrids, s, xt::all(), xt::all(), xt::all()));
 
     subgrid = xt::fftw::ifft2(subgrid);
 

--- a/idg/cpp/src/IDG.cpp
+++ b/idg/cpp/src/IDG.cpp
@@ -6,6 +6,7 @@
 #include <xtensor-fftw/basic.hpp>
 #include <xtensor-fftw/helper.hpp>
 #include <xtensor/containers/xarray.hpp>
+#include <xtensor/core/xtensor_forward.hpp>
 #include <xtensor/views/xview.hpp>
 
 #include "IDG.h"
@@ -23,7 +24,7 @@ void Gridder::grid_onto_subgrids(
   assert(subgrid_size_ == subgrids.shape()[2]);
   const size_t nr_subgrids = metadata.size();
 
-  #pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for schedule(dynamic)
   for (size_t s = 0; s < nr_subgrids; ++s) {
     auto subgrid =
         xt::eval(xt::view(subgrids, s, xt::all(), xt::all(), xt::all()));
@@ -66,8 +67,7 @@ void Gridder::add_subgrids_to_grid(
   }
 }
 
-void Gridder::transform(int direction,
-                        xt::xarray<std::complex<float>> &grid) const {
+void Gridder::transform(xt::xarray<std::complex<float>> &grid) const {
   assert(nr_correlations_out_ == grid.shape()[0]);
   const size_t height = grid.shape()[1];
   const size_t width = grid.shape()[2];
@@ -75,26 +75,30 @@ void Gridder::transform(int direction,
 
   for (size_t i = 0; i < nr_correlations_out_; ++i) {
     auto slice = xt::view(grid, i, xt::all(), xt::all());
-    xt::xarray<std::complex<float>> tmp = slice;
+    auto tmp = xt::xarray<std::complex<float>>::from_shape(slice.shape());
 
-    tmp = xt::fftw::fftshift(tmp);
-
-    if (direction == FourierDomainToImageDomain) {
-      tmp = xt::fftw::ifft2(tmp);
-    } else {
-      tmp = xt::fftw::fft2(tmp);
+    for (size_t x = 0; x < width; ++x) {
+      for (size_t y = 0; y < height; ++y) {
+        size_t dst_x = (x + width / 2) % width;
+        size_t dst_y = (y + height / 2) % height;
+        tmp(dst_y, dst_x) = slice(y, x);
+      }
     }
 
-    tmp = xt::fftw::fftshift(tmp);
+    tmp = xt::fftw::ifft2(tmp);
+
+    for (size_t x = 0; x < width; ++x) {
+      for (size_t y = 0; y < height; ++y) {
+        size_t src_x = (x + width / 2) % width;
+        size_t src_y = (y + height / 2) % height;
+        slice(y, x) = tmp(src_y, src_x);
+      }
+    }
 
     std::complex<float> scale{2.0f, 0.0f};
 
-    if (direction == FourierDomainToImageDomain) {
-      tmp *= scale;
-    } else {
-      tmp /= scale;
-    }
+    slice *= scale;
 
-    slice = tmp;
+    xt::view(grid, i, xt::all(), xt::all()) = slice;
   }
 }

--- a/idg/cpp/src/IDG.cpp
+++ b/idg/cpp/src/IDG.cpp
@@ -23,7 +23,7 @@ void Gridder::grid_onto_subgrids(
   assert(subgrid_size_ == subgrids.shape()[2]);
   const size_t nr_subgrids = metadata.size();
 
-  // #pragma omp parallel for schedule(dynamic)
+  #pragma omp parallel for schedule(dynamic)
   for (size_t s = 0; s < nr_subgrids; ++s) {
     auto subgrid =
         xt::eval(xt::view(subgrids, s, xt::all(), xt::all(), xt::all()));
@@ -42,8 +42,6 @@ void Gridder::ifft_subgrids(xt::xarray<std::complex<float>> &subgrids) const {
       auto subgrid = xt::eval(xt::view(subgrids, s, c, xt::all(), xt::all()));
 
       subgrid = xt::fftw::ifft2(subgrid);
-
-      subgrid = subgrid / (subgrid_size_ * subgrid_size_);
 
       xt::view(subgrids, s, c, xt::all(), xt::all()) = subgrid;
     }

--- a/idg/cpp/src/IDG.cpp
+++ b/idg/cpp/src/IDG.cpp
@@ -32,8 +32,6 @@ void Gridder::grid_onto_subgrids(
                             wavenumbers, visibilities, uvw, taper,
                             nr_correlations_in_, subgrid_size_, subgrid);
 
-    subgrid = xt::fftw::ifft2(subgrid);
-
     xt::view(subgrids, s, xt::all(), xt::all(), xt::all()) = subgrid;
   }
 }

--- a/idg/cpp/src/kernels.cpp
+++ b/idg/cpp/src/kernels.cpp
@@ -330,6 +330,20 @@ void add_subgrid_to_grid(int s, const xt::xarray<Metadata> &metadata,
   }
 }
 
+float compute_lm(float x, float subgrid_size, float image_size) {
+  return (x + 0.5 - (subgrid_size / 2.0)) * image_size / subgrid_size;
+}
+
+float compute_n(float l, float m) {
+  float tmp = l * l + m * m;
+
+  if (tmp >= 1.0) {
+    return 1.0;
+  }
+
+  return tmp / (1.0 + std::sqrt(1.0 - tmp));
+}
+
 void visibilities_to_subgrid(
     size_t s, const xt::xarray<Metadata> &metadata, float w_step, int grid_size,
     float image_size, const xt::xarray<float> &wavenumbers,
@@ -364,10 +378,9 @@ void visibilities_to_subgrid(
   for (size_t y = 0; y < subgrid_size; ++y) {
     for (size_t x = 0; x < subgrid_size; ++x) {
       // Compute l, m, n
-      const float l = (x + 0.5f - half_subgrid) * image_scale;
-      const float m_val = (y + 0.5f - half_subgrid) * image_scale;
-      const float tmp = l * l + m_val * m_val;
-      const float n = tmp / (1.0f + std::sqrt(1.0f - tmp));
+      const float l = compute_lm(x, subgrid_size, image_size);
+      const float m = compute_lm(y, subgrid_size, image_size);
+      const float n = compute_n(l, m);
 
       // Compute pixels
       std::vector<std::complex<float>> pixels(nr_correlations_out,
@@ -379,12 +392,11 @@ void visibilities_to_subgrid(
         const float v = uvw(bl, idx).v;
         const float w = uvw(bl, idx).w;
 
-        const float phase_index = u * l + v * m_val + w * n;
-        const float phase_offset =
-            u_offset * l + v_offset * m_val + w_offset * n;
+        const float phase_index = u * l + v * m + w * n;
+        const float phase_offset = u_offset * l + v_offset * m + w_offset * n;
 
         for (size_t chan = channel_begin; chan < channel_end; ++chan) {
-          const float phase = phase_offset - (phase_index * wavenumbers(chan));
+          const float phase = phase_offset - (phase_index * wavenumbers[chan]);
           std::complex<float> phasor =
               std::exp(std::complex<float>(0.0f, phase));
 

--- a/idg/cpp/src/main.cpp
+++ b/idg/cpp/src/main.cpp
@@ -329,7 +329,7 @@ int main(int argc, const char *argv[]) {
                              wavenumbers, uvw, visibilities, taper, metadata,
                              subgrids);
 
-  gridder.ifft_subgrids(metadata, subgrids);
+  gridder.ifft_subgrids(subgrids);
   auto main_end = std::chrono::high_resolution_clock::now();
   double grid_time =
       std::chrono::duration<double>(main_end - main_start).count();

--- a/idg/cpp/src/main.cpp
+++ b/idg/cpp/src/main.cpp
@@ -5,15 +5,12 @@
 
 #include <cxxopts.hpp>
 #include <xtensor/containers/xarray.hpp>
-#include <xtensor/core/xtensor_forward.hpp>
 #include <xtensor/io/xnpy.hpp>
 
 #include "IDG.h"
-#include "idgtypes.h"
 #include "init.h"
 
 #include "idgtypes-io.h"
-#include "npy-parser.h"
 
 cxxopts::Options setupOptions(const char *argv[]) {
   cxxopts::Options options(argv[0], "Image-Domain Gridder");
@@ -224,8 +221,7 @@ int main(int argc, const char *argv[]) {
 
   // Generate UVW coordinates
   auto init_start = std::chrono::high_resolution_clock::now();
-  // xt::xarray<UVW> uvw = get_uvw(observation_hours, nr_baselines, grid_size);
-  xt::xarray<UVW> uvw = npy_parser::load_npy_uvw("inputs/uvw.npy");
+  xt::xarray<UVW> uvw = get_uvw(observation_hours, nr_baselines, grid_size);
   auto init_end = std::chrono::high_resolution_clock::now();
   double uvw_time =
       std::chrono::duration<double>(init_end - init_start).count();
@@ -240,10 +236,9 @@ int main(int argc, const char *argv[]) {
 
   // Generate frequencies
   init_start = std::chrono::high_resolution_clock::now();
-  // xt::xarray<float> frequencies =
-  //     get_frequencies(static_cast<float>(start_frequency),
-  //                     static_cast<float>(frequency_increment), nr_channels);
-  xt::xarray<float> frequencies = xt::load_npy<float>("inputs/frequencies.npy");
+  xt::xarray<float> frequencies =
+      get_frequencies(static_cast<float>(start_frequency),
+                      static_cast<float>(frequency_increment), nr_channels);
   init_end = std::chrono::high_resolution_clock::now();
   double freq_time =
       std::chrono::duration<double>(init_end - init_start).count();
@@ -255,10 +250,8 @@ int main(int argc, const char *argv[]) {
 
   // Generate metadata
   init_start = std::chrono::high_resolution_clock::now();
-  // xt::xarray<Metadata> metadata =
-  //     get_metadata(nr_channels, subgrid_size, grid_size, uvw);
   xt::xarray<Metadata> metadata =
-      npy_parser::load_npy_metadata("inputs/metadata.npy");
+      get_metadata(nr_channels, subgrid_size, grid_size, uvw);
   init_end = std::chrono::high_resolution_clock::now();
   double meta_time =
       std::chrono::duration<double>(init_end - init_start).count();
@@ -273,11 +266,9 @@ int main(int argc, const char *argv[]) {
 
   // Generate visibilities
   init_start = std::chrono::high_resolution_clock::now();
-  // xt::xarray<VisibilityType> visibilities = get_visibilities(
-  //     nr_correlations_in, nr_channels, nr_timesteps, nr_baselines,
-  //     static_cast<float>(image_size), grid_size, frequencies, uvw);
-  xt::xarray<VisibilityType> visibilities =
-      xt::load_npy<VisibilityType>("inputs/visibilities.npy");
+  xt::xarray<VisibilityType> visibilities = get_visibilities(
+      nr_correlations_in, nr_channels, nr_timesteps, nr_baselines,
+      static_cast<float>(image_size), grid_size, frequencies, uvw);
   init_end = std::chrono::high_resolution_clock::now();
   double vis_time =
       std::chrono::duration<double>(init_end - init_start).count();

--- a/idg/cpp/src/main.cpp
+++ b/idg/cpp/src/main.cpp
@@ -251,14 +251,14 @@ int main(int argc, const char *argv[]) {
   if (arguments.report_timing) {
     print_timing(timings.back());
   }
-  xt::xarray<float> wavenumbers = (frequencies * static_cast<float>(2 * M_PI)) /
-                                  static_cast<float>(speed_of_light);
+  xt::xarray<float> wavenumbers = (frequencies * 2.0 * M_PI) / speed_of_light;
 
   // Generate metadata
   init_start = std::chrono::high_resolution_clock::now();
   // xt::xarray<Metadata> metadata =
   //     get_metadata(nr_channels, subgrid_size, grid_size, uvw);
-  xt::xarray<Metadata> metadata = npy_parser::load_npy_metadata("inputs/metadata.npy");
+  xt::xarray<Metadata> metadata =
+      npy_parser::load_npy_metadata("inputs/metadata.npy");
   init_end = std::chrono::high_resolution_clock::now();
   double meta_time =
       std::chrono::duration<double>(init_end - init_start).count();
@@ -276,7 +276,8 @@ int main(int argc, const char *argv[]) {
   // xt::xarray<VisibilityType> visibilities = get_visibilities(
   //     nr_correlations_in, nr_channels, nr_timesteps, nr_baselines,
   //     static_cast<float>(image_size), grid_size, frequencies, uvw);
-  xt::xarray<VisibilityType> visibilities = xt::load_npy<VisibilityType>("inputs/visibilities.npy");
+  xt::xarray<VisibilityType> visibilities =
+      xt::load_npy<VisibilityType>("inputs/visibilities.npy");
   init_end = std::chrono::high_resolution_clock::now();
   double vis_time =
       std::chrono::duration<double>(init_end - init_start).count();
@@ -325,8 +326,10 @@ int main(int argc, const char *argv[]) {
   // Grid visibilities onto subgrids
   auto main_start = std::chrono::high_resolution_clock::now();
   gridder.grid_onto_subgrids(w_step, static_cast<float>(image_size), grid_size,
-                             frequencies, uvw, visibilities, taper, metadata,
+                             wavenumbers, uvw, visibilities, taper, metadata,
                              subgrids);
+
+  gridder.ifft_subgrids(metadata, subgrids);
   auto main_end = std::chrono::high_resolution_clock::now();
   double grid_time =
       std::chrono::duration<double>(main_end - main_start).count();

--- a/idg/cpp/src/main.cpp
+++ b/idg/cpp/src/main.cpp
@@ -5,12 +5,15 @@
 
 #include <cxxopts.hpp>
 #include <xtensor/containers/xarray.hpp>
+#include <xtensor/core/xtensor_forward.hpp>
 #include <xtensor/io/xnpy.hpp>
 
 #include "IDG.h"
+#include "idgtypes.h"
 #include "init.h"
 
 #include "idgtypes-io.h"
+#include "npy-parser.h"
 
 cxxopts::Options setupOptions(const char *argv[]) {
   cxxopts::Options options(argv[0], "Image-Domain Gridder");
@@ -221,7 +224,8 @@ int main(int argc, const char *argv[]) {
 
   // Generate UVW coordinates
   auto init_start = std::chrono::high_resolution_clock::now();
-  xt::xarray<UVW> uvw = get_uvw(observation_hours, nr_baselines, grid_size);
+  // xt::xarray<UVW> uvw = get_uvw(observation_hours, nr_baselines, grid_size);
+  xt::xarray<UVW> uvw = npy_parser::load_npy_uvw("inputs/uvw.npy");
   auto init_end = std::chrono::high_resolution_clock::now();
   double uvw_time =
       std::chrono::duration<double>(init_end - init_start).count();
@@ -236,9 +240,10 @@ int main(int argc, const char *argv[]) {
 
   // Generate frequencies
   init_start = std::chrono::high_resolution_clock::now();
-  xt::xarray<float> frequencies =
-      get_frequencies(static_cast<float>(start_frequency),
-                      static_cast<float>(frequency_increment), nr_channels);
+  // xt::xarray<float> frequencies =
+  //     get_frequencies(static_cast<float>(start_frequency),
+  //                     static_cast<float>(frequency_increment), nr_channels);
+  xt::xarray<float> frequencies = xt::load_npy<float>("inputs/frequencies.npy");
   init_end = std::chrono::high_resolution_clock::now();
   double freq_time =
       std::chrono::duration<double>(init_end - init_start).count();
@@ -251,8 +256,9 @@ int main(int argc, const char *argv[]) {
 
   // Generate metadata
   init_start = std::chrono::high_resolution_clock::now();
-  xt::xarray<Metadata> metadata =
-      get_metadata(nr_channels, subgrid_size, grid_size, uvw);
+  // xt::xarray<Metadata> metadata =
+  //     get_metadata(nr_channels, subgrid_size, grid_size, uvw);
+  xt::xarray<Metadata> metadata = npy_parser::load_npy_metadata("inputs/metadata.npy");
   init_end = std::chrono::high_resolution_clock::now();
   double meta_time =
       std::chrono::duration<double>(init_end - init_start).count();
@@ -267,9 +273,10 @@ int main(int argc, const char *argv[]) {
 
   // Generate visibilities
   init_start = std::chrono::high_resolution_clock::now();
-  xt::xarray<VisibilityType> visibilities = get_visibilities(
-      nr_correlations_in, nr_channels, nr_timesteps, nr_baselines,
-      static_cast<float>(image_size), grid_size, frequencies, uvw);
+  // xt::xarray<VisibilityType> visibilities = get_visibilities(
+  //     nr_correlations_in, nr_channels, nr_timesteps, nr_baselines,
+  //     static_cast<float>(image_size), grid_size, frequencies, uvw);
+  xt::xarray<VisibilityType> visibilities = xt::load_npy<VisibilityType>("inputs/visibilities.npy");
   init_end = std::chrono::high_resolution_clock::now();
   double vis_time =
       std::chrono::duration<double>(init_end - init_start).count();

--- a/idg/cpp/src/main.cpp
+++ b/idg/cpp/src/main.cpp
@@ -357,7 +357,7 @@ int main(int argc, const char *argv[]) {
 
   // Transform to image domain
   main_start = std::chrono::high_resolution_clock::now();
-  gridder.transform(FourierDomainToImageDomain, grid);
+  gridder.transform(grid);
   main_end = std::chrono::high_resolution_clock::now();
   double transform_time =
       std::chrono::duration<double>(main_end - main_start).count();

--- a/idg/cpp/src/npy-parser.cpp
+++ b/idg/cpp/src/npy-parser.cpp
@@ -1,132 +1,92 @@
 #include "npy-parser.h"
-#include "idgtypes.h"
+#include <algorithm>
 #include <cstdint>
-#include <cstdio>
 #include <fstream>
 #include <ios>
+#include <memory>
 #include <stdexcept>
-#include <sys/types.h>
-#include <xtensor/containers/xadapt.hpp>
-#include <xtensor/containers/xarray.hpp>
-#include <xtensor/containers/xbuffer_adaptor.hpp>
-#include <xtensor/core/xlayout.hpp>
-#include <xtensor/core/xstrides.hpp>
-#include <xtensor/core/xtensor_forward.hpp>
-
-xt::xarray<UVW> npy_parser::load_npy_uvw(const std::string &filename) {
-  std::ifstream stream(filename, std::ifstream::binary);
-  if (!stream) {
-    XTENSOR_THROW(std::runtime_error, "io error: failed to open a file.");
-  }
-
-  unsigned char v_major, v_minor;
-  read_magic(stream, &v_major, &v_minor);
-
-  std::string header;
-
-  if (v_major == 1 && v_minor == 0) {
-    header = read_header_1_0(stream);
-  } else if (v_major == 2 && v_minor == 0) {
-    header = read_header_2_0(stream);
-  } else {
-    XTENSOR_THROW(std::runtime_error, "unsupported file format version.");
-  }
-
-  bool fortran_order;
-  std::string typestr;
-  std::vector<std::size_t> shape;
-
-  parse_header(header, typestr, &fortran_order, shape);
-
-  if (typestr != "[('u','<f4'),('v','<f4'),('w','<f4')]") {
-    XTENSOR_THROW(std::runtime_error,
-                  "type does not match expected UVW layout.");
-  }
-
-  constexpr size_t item_size = 3 * 4;
-  size_t item_count = xt::compute_size(shape);
-  size_t buffer_size = item_count * item_size;
-  std::vector<size_t> strides(shape.size());
-  xt::compute_strides(shape,
-                      fortran_order ? xt::layout_type::column_major
-                                    : xt::layout_type::row_major,
-                      strides);
-
-  char *buf = std::allocator<char>{}.allocate(buffer_size);
-  if (buf == nullptr) {
-    XTENSOR_THROW(std::runtime_error, "Allocation failed.");
-  }
-
-  stream.read(buf, std::streamsize(buffer_size));
-
-  auto uvws = reinterpret_cast<UVW *>(buf);
-
-  xt::xarray<UVW> output = xt::adapt(uvws, item_count, xt::no_ownership(),
-                                     std::move(shape), std::move(strides));
-
-  return output;
-}
-
-xt::xarray<Metadata>
-npy_parser::load_npy_metadata(const std::string &filename) {
-  std::ifstream stream(filename, std::ifstream::binary);
-  if (!stream) {
-    XTENSOR_THROW(std::runtime_error, "io error: failed to open a file.");
-  }
-
-  unsigned char v_major, v_minor;
-  read_magic(stream, &v_major, &v_minor);
-
-  std::string header;
-
-  if (v_major == 1 && v_minor == 0) {
-    header = read_header_1_0(stream);
-  } else if (v_major == 2 && v_minor == 0) {
-    header = read_header_2_0(stream);
-  } else {
-    XTENSOR_THROW(std::runtime_error, "unsupported file format version.");
-  }
-
-  bool fortran_order;
-  std::string typestr;
-  std::vector<std::size_t> shape;
-
-  parse_header(header, typestr, &fortran_order, shape);
-
-  if (typestr !=
-      "[('baseline','<i4'),('time_index','<i4'),('nr_timesteps','<i4'),"
-      "('channel_begin','<i4'),('channel_end','<i4'),('coordinate',[('x',"
-      "'<i4'),('y','<i4'),('z','<i4')])]") {
-    XTENSOR_THROW(std::runtime_error,
-                  "type does not match expected Metadata layout.");
-  }
-
-  constexpr size_t item_size = 8 * 4;
-  size_t item_count = xt::compute_size(shape);
-  size_t buffer_size = item_count * item_size;
-  std::vector<size_t> strides(shape.size());
-  xt::compute_strides(shape,
-                      fortran_order ? xt::layout_type::column_major
-                                    : xt::layout_type::row_major,
-                      strides);
-
-  char *buf = std::allocator<char>{}.allocate(buffer_size);
-  if (buf == nullptr) {
-    XTENSOR_THROW(std::runtime_error, "Allocation failed.");
-  }
-
-  stream.read(buf, std::streamsize(buffer_size));
-
-  auto uvws = reinterpret_cast<Metadata *>(buf);
-
-  xt::xarray<Metadata> output = xt::adapt(uvws, item_count, xt::no_ownership(),
-                                          std::move(shape), std::move(strides));
-
-  return output;
-}
 
 const char magic_string[] = "\x93NUMPY";
 const std::size_t magic_string_length = sizeof(magic_string) - 1;
+
+namespace npy_parser {
+void read_magic(std::istream &istream, unsigned char *v_major,
+                unsigned char *v_minor);
+std::string read_header_1_0(std::istream &istream);
+std::string read_header_2_0(std::istream &istream);
+void parse_header(std::string header, std::string &descr, bool *fortran_order,
+                  std::vector<std::size_t> &shape);
+std::string unwrap_s(std::string s, char delim_front, char delim_back);
+std::string get_value_from_map(std::string mapstr);
+void pop_char(std::string &s, char c);
+} // namespace npy_parser
+
+npy_parser::npy_header
+npy_parser::load_npy_header(const std::string &filename) {
+  std::ifstream stream(filename, std::ifstream::binary);
+  if (!stream) {
+    XTENSOR_THROW(std::runtime_error, "io error: failed to open a file.");
+  }
+
+  return load_npy_header(stream);
+}
+
+npy_parser::npy_header npy_parser::load_npy_header(std::istream &istream) {
+  unsigned char v_major, v_minor;
+  read_magic(istream, &v_major, &v_minor);
+
+  std::string header;
+  if (v_major == 1 && v_minor == 0) {
+    header = read_header_1_0(istream);
+  } else if (v_major == 2 && v_minor == 0) {
+    header = read_header_2_0(istream);
+  } else {
+    XTENSOR_THROW(std::runtime_error, "unsupported file format version.");
+  }
+
+  npy_header output;
+  parse_header(header, output.descr, &output.fortran_order, output.shape);
+  return output;
+}
+
+void npy_parser::write_npy_header(std::ostream &ostream, std::string_view descr,
+                                  const std::vector<std::size_t> &shape,
+                                  bool fortran_order) {
+  static constexpr char magic[] = {'\x93', 'N', 'U', 'M', 'P', 'Y'};
+  static constexpr char version[] = {1, 0};
+
+  ostream.write(magic, sizeof(magic));
+  ostream.write(version, sizeof(version));
+
+  std::string shape_str = "(";
+  for (std::size_t i = 0; i < shape.size(); ++i) {
+    if (i > 0) {
+      shape_str += ", ";
+    }
+    shape_str += std::to_string(shape[i]);
+  }
+  if (shape.size() == 1) {
+    shape_str += ",";
+  }
+  shape_str += ")";
+
+  std::string header = "{'descr': ";
+  header += descr;
+  header += ", 'fortran_order': ";
+  header += fortran_order ? "True" : "False";
+  header += ", 'shape': ";
+  header += shape_str;
+  header += ", }";
+
+  const std::size_t header_len = header.size() + 1;
+  const std::size_t padding = (64 - ((10 + header_len) % 64)) % 64;
+  header.append(padding, ' ');
+  header += '\n';
+
+  const uint16_t header_len_le = static_cast<uint16_t>(header.size());
+  ostream.write(reinterpret_cast<const char *>(&header_len_le), 2);
+  ostream.write(header.data(), std::streamsize(header.size()));
+}
 
 inline void npy_parser::read_magic(std::istream &istream,
                                    unsigned char *v_major,

--- a/idg/cpp/src/npy-parser.cpp
+++ b/idg/cpp/src/npy-parser.cpp
@@ -154,9 +154,11 @@ inline std::string npy_parser::read_header_1_0(std::istream &istream) {
   char header_len_le16[2];
   istream.read(header_len_le16, 2);
 
-  uint16_t header_top = (uint16_t)(uint8_t)(header_len_le16[0]);
-  uint16_t header_btm = (uint16_t)(uint8_t)(header_len_le16[1]) << 8;
-  uint16_t header_length = header_top | header_btm;
+  uint16_t header_b0 =
+      static_cast<uint16_t>(static_cast<uint8_t>(header_len_le16[0]));
+  uint16_t header_b1 =
+      static_cast<uint16_t>(static_cast<uint8_t>(header_len_le16[1])) << 8;
+  uint16_t header_length = header_b0 | header_b1;
 
   if ((magic_string_length + 2 + 2 + header_length) % 16 != 0) {
     // TODO: display warning
@@ -174,9 +176,15 @@ inline std::string npy_parser::read_header_2_0(std::istream &istream) {
   char header_len_le32[4];
   istream.read(header_len_le32, 4);
 
-  uint32_t header_length =
-      uint32_t(header_len_le32[0] << 0) | uint32_t(header_len_le32[1] << 8) |
-      uint32_t(header_len_le32[2] << 16) | uint32_t(header_len_le32[3] << 24);
+  uint32_t header_b0 =
+      static_cast<uint32_t>(static_cast<uint8_t>(header_len_le32[0]));
+  uint32_t header_b1 =
+      static_cast<uint32_t>(static_cast<uint8_t>(header_len_le32[1])) << 8;
+  uint32_t header_b2 =
+      static_cast<uint32_t>(static_cast<uint8_t>(header_len_le32[2])) << 16;
+  uint32_t header_b3 =
+      static_cast<uint32_t>(static_cast<uint8_t>(header_len_le32[3])) << 24;
+  uint32_t header_length = header_b0 | header_b1 | header_b2 | header_b3;
 
   if ((magic_string_length + 2 + 4 + header_length) % 16 != 0) {
     // TODO: display warning

--- a/idg/cpp/src/npy-parser.cpp
+++ b/idg/cpp/src/npy-parser.cpp
@@ -1,0 +1,351 @@
+#include "npy-parser.h"
+#include "idgtypes.h"
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <ios>
+#include <stdexcept>
+#include <sys/types.h>
+#include <xtensor/containers/xadapt.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/containers/xbuffer_adaptor.hpp>
+#include <xtensor/core/xlayout.hpp>
+#include <xtensor/core/xstrides.hpp>
+#include <xtensor/core/xtensor_forward.hpp>
+
+xt::xarray<UVW> npy_parser::load_npy_uvw(const std::string &filename) {
+  std::ifstream stream(filename, std::ifstream::binary);
+  if (!stream) {
+    XTENSOR_THROW(std::runtime_error, "io error: failed to open a file.");
+  }
+
+  unsigned char v_major, v_minor;
+  read_magic(stream, &v_major, &v_minor);
+
+  std::string header;
+
+  if (v_major == 1 && v_minor == 0) {
+    header = read_header_1_0(stream);
+  } else if (v_major == 2 && v_minor == 0) {
+    header = read_header_2_0(stream);
+  } else {
+    XTENSOR_THROW(std::runtime_error, "unsupported file format version.");
+  }
+
+  bool fortran_order;
+  std::string typestr;
+  std::vector<std::size_t> shape;
+
+  parse_header(header, typestr, &fortran_order, shape);
+
+  if (typestr != "[('u','<f4'),('v','<f4'),('w','<f4')]") {
+    XTENSOR_THROW(std::runtime_error,
+                  "type does not match expected UVW layout.");
+  }
+
+  constexpr size_t item_size = 3 * 4;
+  size_t item_count = xt::compute_size(shape);
+  size_t buffer_size = item_count * item_size;
+  std::vector<size_t> strides(shape.size());
+  xt::compute_strides(shape,
+                      fortran_order ? xt::layout_type::column_major
+                                    : xt::layout_type::row_major,
+                      strides);
+
+  char *buf = std::allocator<char>{}.allocate(buffer_size);
+  if (buf == nullptr) {
+    XTENSOR_THROW(std::runtime_error, "Allocation failed.");
+  }
+
+  stream.read(buf, std::streamsize(buffer_size));
+
+  auto uvws = reinterpret_cast<UVW *>(buf);
+
+  xt::xarray<UVW> output = xt::adapt(uvws, item_count, xt::no_ownership(),
+                                     std::move(shape), std::move(strides));
+
+  return output;
+}
+
+xt::xarray<Metadata>
+npy_parser::load_npy_metadata(const std::string &filename) {
+  std::ifstream stream(filename, std::ifstream::binary);
+  if (!stream) {
+    XTENSOR_THROW(std::runtime_error, "io error: failed to open a file.");
+  }
+
+  unsigned char v_major, v_minor;
+  read_magic(stream, &v_major, &v_minor);
+
+  std::string header;
+
+  if (v_major == 1 && v_minor == 0) {
+    header = read_header_1_0(stream);
+  } else if (v_major == 2 && v_minor == 0) {
+    header = read_header_2_0(stream);
+  } else {
+    XTENSOR_THROW(std::runtime_error, "unsupported file format version.");
+  }
+
+  bool fortran_order;
+  std::string typestr;
+  std::vector<std::size_t> shape;
+
+  parse_header(header, typestr, &fortran_order, shape);
+
+  if (typestr !=
+      "[('baseline','<i4'),('time_index','<i4'),('nr_timesteps','<i4'),"
+      "('channel_begin','<i4'),('channel_end','<i4'),('coordinate',[('x',"
+      "'<i4'),('y','<i4'),('z','<i4')])]") {
+    XTENSOR_THROW(std::runtime_error,
+                  "type does not match expected Metadata layout.");
+  }
+
+  constexpr size_t item_size = 8 * 4;
+  size_t item_count = xt::compute_size(shape);
+  size_t buffer_size = item_count * item_size;
+  std::vector<size_t> strides(shape.size());
+  xt::compute_strides(shape,
+                      fortran_order ? xt::layout_type::column_major
+                                    : xt::layout_type::row_major,
+                      strides);
+
+  char *buf = std::allocator<char>{}.allocate(buffer_size);
+  if (buf == nullptr) {
+    XTENSOR_THROW(std::runtime_error, "Allocation failed.");
+  }
+
+  stream.read(buf, std::streamsize(buffer_size));
+
+  auto uvws = reinterpret_cast<Metadata *>(buf);
+
+  xt::xarray<Metadata> output = xt::adapt(uvws, item_count, xt::no_ownership(),
+                                          std::move(shape), std::move(strides));
+
+  return output;
+}
+
+const char magic_string[] = "\x93NUMPY";
+const std::size_t magic_string_length = sizeof(magic_string) - 1;
+
+inline void npy_parser::read_magic(std::istream &istream,
+                                   unsigned char *v_major,
+                                   unsigned char *v_minor) {
+  std::unique_ptr<char[]> buf(new char[magic_string_length + 2]);
+  istream.read(buf.get(), magic_string_length + 2);
+
+  if (!istream) {
+    XTENSOR_THROW(std::runtime_error, "io error: failed reading file");
+  }
+
+  for (std::size_t i = 0; i < magic_string_length; i++) {
+    if (buf[i] != magic_string[i]) {
+      XTENSOR_THROW(std::runtime_error,
+                    "this file do not have a valid npy format.");
+    }
+  }
+
+  *v_major = static_cast<unsigned char>(buf[magic_string_length]);
+  *v_minor = static_cast<unsigned char>(buf[magic_string_length + 1]);
+}
+
+inline std::string npy_parser::read_header_1_0(std::istream &istream) {
+  // read header length and convert from little endian
+  char header_len_le16[2];
+  istream.read(header_len_le16, 2);
+
+  uint16_t header_top = (uint16_t)(uint8_t)(header_len_le16[0]);
+  uint16_t header_btm = (uint16_t)(uint8_t)(header_len_le16[1]) << 8;
+  uint16_t header_length = header_top | header_btm;
+
+  if ((magic_string_length + 2 + 2 + header_length) % 16 != 0) {
+    // TODO: display warning
+  }
+
+  std::unique_ptr<char[]> buf(new char[header_length]);
+  istream.read(buf.get(), header_length);
+  std::string header(buf.get(), header_length);
+
+  return header;
+}
+
+inline std::string npy_parser::read_header_2_0(std::istream &istream) {
+  // read header length and convert from little endian
+  char header_len_le32[4];
+  istream.read(header_len_le32, 4);
+
+  uint32_t header_length =
+      uint32_t(header_len_le32[0] << 0) | uint32_t(header_len_le32[1] << 8) |
+      uint32_t(header_len_le32[2] << 16) | uint32_t(header_len_le32[3] << 24);
+
+  if ((magic_string_length + 2 + 4 + header_length) % 16 != 0) {
+    // TODO: display warning
+  }
+
+  std::unique_ptr<char[]> buf(new char[header_length]);
+  istream.read(buf.get(), header_length);
+  std::string header(buf.get(), header_length);
+
+  return header;
+}
+
+inline void npy_parser::parse_header(std::string header, std::string &descr,
+                                     bool *fortran_order,
+                                     std::vector<std::size_t> &shape) {
+  // The first 6 bytes are a magic string: exactly "x93NUMPY".
+  //
+  // The next 1 byte is an unsigned byte: the major version number of the file
+  // format, e.g. x01.
+  //
+  // The next 1 byte is an unsigned byte: the minor version number of the file
+  // format, e.g. x00. Note: the version of the file format is not tied to the
+  // version of the NumPy package.
+  //
+  // The next 2 bytes form a little-endian unsigned short int: the length of the
+  // header data HEADER_LEN.
+  //
+  // The next HEADER_LEN bytes form the header data describing the array's
+  // format. It is an ASCII string which contains a Python literal expression of
+  // a dictionary. It is terminated by a newline ('n') and padded with spaces
+  // ('x20') to make the total length of the magic string + 4 + HEADER_LEN be
+  // evenly divisible by 16 for alignment purposes.
+  //
+  // The dictionary contains three keys:
+  //
+  // "descr" : dtype.descr
+  // An object that can be passed as an argument to the numpy.dtype()
+  // constructor to create the array's dtype.
+  // "fortran_order" : bool
+  // Whether the array data is Fortran-contiguous or not. Since
+  // Fortran-contiguous arrays are a common form of non-C-contiguity, we allow
+  // them to be written directly to disk for efficiency.
+  // "shape" : tuple of int
+  // The shape of the array.
+  // For repeatability and readability, this dictionary is formatted using
+  // pprint.pformat() so the keys are in alphabetic order.
+
+  // remove trailing newline
+  if (header.back() != '\n') {
+    XTENSOR_THROW(std::runtime_error, "invalid header");
+  }
+  header.pop_back();
+
+  // remove all whitespaces
+  header.erase(std::remove(header.begin(), header.end(), ' '), header.end());
+
+  // unwrap dictionary
+  header = unwrap_s(header, '{', '}');
+
+  // find the positions of the 3 dictionary keys
+  std::size_t keypos_descr = header.find("'descr'");
+  std::size_t keypos_fortran = header.find("'fortran_order'");
+  std::size_t keypos_shape = header.find("'shape'");
+
+  // make sure all the keys are present
+  if (keypos_descr == std::string::npos) {
+    XTENSOR_THROW(std::runtime_error, "missing 'descr' key");
+  }
+  if (keypos_fortran == std::string::npos) {
+    XTENSOR_THROW(std::runtime_error, "missing 'fortran_order' key");
+  }
+  if (keypos_shape == std::string::npos) {
+    XTENSOR_THROW(std::runtime_error, "missing 'shape' key");
+  }
+
+  // Make sure the keys are in order.
+  // Note that this violates the standard, which states that readers *must* not
+  // depend on the correct order here.
+  // TODO: fix
+  if (keypos_descr >= keypos_fortran || keypos_fortran >= keypos_shape) {
+    XTENSOR_THROW(std::runtime_error, "header keys in wrong order");
+  }
+
+  // get the 3 key-value pairs
+  std::string keyvalue_descr;
+  keyvalue_descr = header.substr(keypos_descr, keypos_fortran - keypos_descr);
+  pop_char(keyvalue_descr, ',');
+
+  std::string keyvalue_fortran;
+  keyvalue_fortran =
+      header.substr(keypos_fortran, keypos_shape - keypos_fortran);
+  pop_char(keyvalue_fortran, ',');
+
+  std::string keyvalue_shape;
+  keyvalue_shape = header.substr(keypos_shape, std::string::npos);
+  pop_char(keyvalue_shape, ',');
+
+  // get the values (right side of `:')
+  descr = get_value_from_map(keyvalue_descr);
+  std::string fortran_s = get_value_from_map(keyvalue_fortran);
+  std::string shape_s = get_value_from_map(keyvalue_shape);
+
+  // convert literal Python bool to C++ bool
+  if (fortran_s == "True") {
+    *fortran_order = true;
+  } else if (fortran_s == "False") {
+    *fortran_order = false;
+  } else {
+    XTENSOR_THROW(std::runtime_error, "invalid fortran_order value");
+  }
+
+  // parse the shape Python tuple ( x, y, z,)
+
+  // first clear the vector
+  shape.clear();
+  shape_s = unwrap_s(shape_s, '(', ')');
+
+  // a tokenizer would be nice...
+  std::size_t pos = 0;
+  for (;;) {
+    std::size_t pos_next = shape_s.find_first_of(',', pos);
+    std::string dim_s;
+
+    if (pos_next != std::string::npos) {
+      dim_s = shape_s.substr(pos, pos_next - pos);
+    } else {
+      dim_s = shape_s.substr(pos);
+    }
+
+    if (dim_s.length() == 0) {
+      if (pos_next != std::string::npos) {
+        XTENSOR_THROW(std::runtime_error, "invalid shape");
+      }
+    } else {
+      std::stringstream ss;
+      ss << dim_s;
+      std::size_t tmp;
+      ss >> tmp;
+      shape.push_back(tmp);
+    }
+
+    if (pos_next != std::string::npos) {
+      pos = ++pos_next;
+    } else {
+      break;
+    }
+  }
+}
+
+inline std::string npy_parser::unwrap_s(std::string s, char delim_front,
+                                        char delim_back) {
+  if ((s.back() == delim_back) && (s.front() == delim_front)) {
+    return s.substr(1, s.length() - 2);
+  } else {
+    XTENSOR_THROW(std::runtime_error, "unable to unwrap");
+  }
+}
+
+inline std::string npy_parser::get_value_from_map(std::string mapstr) {
+  std::size_t sep_pos = mapstr.find_first_of(":");
+  if (sep_pos == std::string::npos) {
+    return "";
+  }
+
+  return mapstr.substr(sep_pos + 1);
+}
+
+inline void npy_parser::pop_char(std::string &s, char c) {
+  if (s.back() == c) {
+    s.pop_back();
+  }
+}


### PR DESCRIPTION
Fixed several issues. The gridder now produces output equal to the Rust and Python implementations (to within float rounding error). It also runs at around the same order of speed.