### PR TITLE
Optimise dedispersion routine

### DIFF
--- a/dedisp/cpp/CMakeLists.txt
+++ b/dedisp/cpp/CMakeLists.txt
@@ -21,6 +21,11 @@ if(DEDISP_DEBUG_NPY)
   add_definitions(-DDEDISP_DEBUG_NPY)
 endif()
 
+option(DEDISP_USE_OPENMP "Use OpenMP to parallise loops" ON)
+if(DEDISP_USE_OPENMP)
+  add_definitions(-DDEDISP_USE_OPENMP)
+endif()
+
 # Load external dependencies
 include(FetchContent)
 

--- a/dedisp/cpp/CMakeLists.txt
+++ b/dedisp/cpp/CMakeLists.txt
@@ -26,6 +26,11 @@ if(DEDISP_USE_OPENMP)
   add_definitions(-DDEDISP_USE_OPENMP)
 endif()
 
+option(DEDISP_BENCHMARK "Print dedispersion timings" ON)
+if(DEDISP_BENCHMARK)
+  add_definitions(-DDEDISP_BENCHMARK)
+endif()
+
 # Load external dependencies
 include(FetchContent)
 

--- a/dedisp/cpp/include/utilities.hpp
+++ b/dedisp/cpp/include/utilities.hpp
@@ -21,7 +21,9 @@ template <typename InputType, typename OutputType>
 void transpose_data(size_t height, size_t width, size_t in_stride,
                     size_t out_stride, float offset, float scale,
                     const InputType *input, OutputType *output) {
+#ifdef DEDISP_USE_OPENMP
 #pragma omp parallel for
+#endif
   for (size_t y = 0; y < height; ++y) {
     for (size_t x = 0; x < width; ++x) {
       const InputType *input_ptr = &input[x * in_stride];

--- a/dedisp/cpp/src/fddplan.cpp
+++ b/dedisp/cpp/src/fddplan.cpp
@@ -77,7 +77,9 @@ xt::xarray<float> FDDPlan::execute(const xt::xarray<uint8_t> &input) {
   xt::xarray<std::complex<float>> fd_scratch =
       xt::zeros<std::complex<float>>(fd_scratch_shape);
 
+#ifdef DEDISP_USE_OPENMP
 #pragma omp parallel for
+#endif
   for (size_t c = 0; c < n_channels_; ++c) {
     xt::xarray<float> samples = xt::eval(xt::row(transposed_input, c));
     xt::view(fd_scratch, c, xt::all()) = xt::fftw::rfft(samples);
@@ -114,7 +116,9 @@ xt::xarray<float> FDDPlan::execute(const xt::xarray<uint8_t> &input) {
   const std::vector<size_t> output_shape = {dm_count_, n_samples_padded};
   xt::xarray<float> dm_data = xt::zeros<float>(output_shape);
 
+#ifdef DEDISP_USE_OPENMP
 #pragma omp parallel for
+#endif
   for (size_t d = 0; d < dm_count_; ++d) {
     xt::xarray<std::complex<float>> samples = xt::eval(xt::row(dm_scratch, d));
     xt::view(dm_data, d, xt::all()) = xt::fftw::irfft(samples);
@@ -229,7 +233,9 @@ void FDDPlan::generate_spin_frequency_table(size_t n_spin_frequencies,
                                             size_t n_samples) {
   spin_frequency_table_.resize({n_spin_frequencies});
 
+#ifdef DEDISP_USE_OPENMP
 #pragma omp parallel for
+#endif
   for (size_t i = 0; i < n_spin_frequencies; ++i) {
     spin_frequency_table_(i) = i * (1.0f / (n_samples * time_resolution_));
   }

--- a/dedisp/cpp/src/fddplan.cpp
+++ b/dedisp/cpp/src/fddplan.cpp
@@ -42,16 +42,37 @@ xt::xarray<float> FDDPlan::execute(const xt::xarray<uint8_t> &input) {
   std::cout << "n_fft_frequency_bins = " << n_fft_frequency_bins << '\n';
 #endif
 
+#ifdef DEDISP_BENCHMARK
+  auto init_timer = std::make_unique<dedisp::benchmark::Timer>();
+  auto preprocessing_timer = std::make_unique<dedisp::benchmark::Timer>();
+  auto dedispersion_timer = std::make_unique<dedisp::benchmark::Timer>();
+  auto postprocessing_timer = std::make_unique<dedisp::benchmark::Timer>();
+  auto output_timer = std::make_unique<dedisp::benchmark::Timer>();
+#endif
+
   // 1. Generate spin table
   std::cout << "(1) Generate the spin frequency table." << std::endl;
 
+#ifdef DEDISP_BENCHMARK
+  init_timer->start();
+#endif
+
   generate_spin_frequency_table(n_spin_frequencies, n_samples);
+
+#ifdef DEDISP_BENCHMARK
+  init_timer->pause();
+#endif
+
 #ifdef DEDISP_DEBUG
   std::cout << spin_frequency_table_ << std::endl;
 #endif
 
   // 2. Transpose data (convert input bytes to floats)
   std::cout << "(2) Transpose data: int -> float." << std::endl;
+
+#ifdef DEDISP_BENCHMARK
+  preprocessing_timer->start();
+#endif
 
   // Input is in the frequency domain, while the output is in the DM domain.
   const std::vector<size_t> transposed_shape = {n_channels_, n_samples_padded};
@@ -62,6 +83,10 @@ xt::xarray<float> FDDPlan::execute(const xt::xarray<uint8_t> &input) {
                                  n_samples_padded, byte_offset, n_channels_,
                                  input.data(), transposed_input.data());
 
+#ifdef DEDISP_BENCHMARK
+  preprocessing_timer->pause();
+#endif
+
 #ifdef DEDISP_DEBUG_NPY
   const std::string fn_transpose{"fdd-transpose.npy"};
   xt::dump_npy(fn_transpose, transposed_input);
@@ -71,11 +96,22 @@ xt::xarray<float> FDDPlan::execute(const xt::xarray<uint8_t> &input) {
   // Perform an FFT batched over frequency using OpenMP
   std::cout << "(3) Forward FFT: real-to-complex." << std::endl;
 
+#ifdef DEDISP_BENCHMARK
+  init_timer->start();
+#endif
+
   // Scratch space to store the Fourier-domain (FD) data
   const std::vector<size_t> fd_scratch_shape = {n_channels_,
                                                 n_fft_frequency_bins};
   xt::xarray<std::complex<float>> fd_scratch =
       xt::zeros<std::complex<float>>(fd_scratch_shape);
+
+#ifdef DEDISP_BENCHMARK
+  init_timer->pause();
+#endif
+#ifdef DEDISP_BENCHMARK
+  preprocessing_timer->start();
+#endif
 
 #ifdef DEDISP_USE_OPENMP
 #pragma omp parallel for
@@ -85,6 +121,10 @@ xt::xarray<float> FDDPlan::execute(const xt::xarray<uint8_t> &input) {
     xt::view(fd_scratch, c, xt::all()) = xt::fftw::rfft(samples);
   }
 
+#ifdef DEDISP_BENCHMARK
+  preprocessing_timer->pause();
+#endif
+
 #ifdef DEDISP_DEBUG_NPY
   const std::string fn_r2c{"fdd-fft-r2c.npy"};
   xt::dump_npy(fn_r2c, fd_scratch);
@@ -93,16 +133,32 @@ xt::xarray<float> FDDPlan::execute(const xt::xarray<uint8_t> &input) {
   // 4. Run dedispersion algorithm (CPU reference or optimised version)
   std::cout << "(4) Run dedispersion algorithm." << std::endl;
 
+#ifdef DEDISP_BENCHMARK
+  init_timer->start();
+#endif
+
   const std::vector<size_t> dm_scratch_shape = {dm_count_,
                                                 n_fft_frequency_bins};
   xt::xarray<std::complex<float>> dm_scratch =
       xt::zeros<std::complex<float>>(dm_scratch_shape);
+
+#ifdef DEDISP_BENCHMARK
+  init_timer->pause();
+#endif
+
+#ifdef DEDISP_BENCHMARK
+  dedispersion_timer->start();
+#endif
 
   const size_t in_out_stride = n_fft_frequency_bins;
   dedisp::fourier_domain_dedisperse(
       dm_count_, n_spin_frequencies, n_channels_, time_resolution_,
       spin_frequency_table_.data(), dm_table_.data(), delay_table_.data(),
       in_out_stride, in_out_stride, fd_scratch.data(), dm_scratch.data());
+
+#ifdef DEDISP_BENCHMARK
+  dedispersion_timer->pause();
+#endif
 
 #ifdef DEDISP_DEBUG_NPY
   const std::string fn_dedisp{"fdd-dedisp.npy"};
@@ -113,8 +169,19 @@ xt::xarray<float> FDDPlan::execute(const xt::xarray<uint8_t> &input) {
   // Perform an FFT batched along the DM axis using OpenMP
   std::cout << "(5) Inverse FFT: complex-to-real." << std::endl;
 
+#ifdef DEDISP_BENCHMARK
+  init_timer->start();
+#endif
+
   const std::vector<size_t> output_shape = {dm_count_, n_samples_padded};
   xt::xarray<float> dm_data = xt::zeros<float>(output_shape);
+
+#ifdef DEDISP_BENCHMARK
+  init_timer->pause();
+#endif
+#ifdef DEDISP_BENCHMARK
+  postprocessing_timer->start();
+#endif
 
 #ifdef DEDISP_USE_OPENMP
 #pragma omp parallel for
@@ -124,18 +191,53 @@ xt::xarray<float> FDDPlan::execute(const xt::xarray<uint8_t> &input) {
     xt::view(dm_data, d, xt::all()) = xt::fftw::irfft(samples);
   }
 
+#ifdef DEDISP_BENCHMARK
+  postprocessing_timer->pause();
+#endif
+#ifdef DEDISP_BENCHMARK
+  init_timer->start();
+#endif
+
   // Copy the output of the FFT into an xarray with the expected output shape
   const std::vector<size_t> computed_shape = {n_output_samples, dm_count_};
   xt::xarray<float> computed_data(computed_shape);
+
+#ifdef DEDISP_BENCHMARK
+  init_timer->pause();
+#endif
+
 #ifdef DEDISP_DEBUG
   std::cout << "output samps = " << computed_data.shape(0)
             << "; DM count = " << computed_data.shape(1) << '\n';
+#endif
+#ifdef DEDISP_BENCHMARK
+  output_timer->start();
 #endif
   for (size_t s = 0; s < n_output_samples; ++s) {
     for (size_t d = 0; d < dm_count_; ++d) {
       xt::view(computed_data, s, d) = xt::view(dm_data, d, s);
     }
   }
+
+#ifdef DEDISP_BENCHMARK
+  output_timer->pause();
+  // total_timer->pause();
+
+  // Print timings
+  // std::cout << "FDDPlan::execute() runtime:" << std::endl;
+  std::cout << std::endl;
+  std::cout << "Initialization time : " << init_timer->duration() << " sec."
+            << std::endl;
+  std::cout << "Preprocessing time  : " << preprocessing_timer->duration()
+            << " sec." << std::endl;
+  std::cout << "Dedispersion time   : " << dedispersion_timer->duration()
+            << " sec." << std::endl;
+  std::cout << "Postprocessing time : " << postprocessing_timer->duration()
+            << " sec." << std::endl;
+  std::cout << "Output copy time    : " << output_timer->duration() << " sec."
+            << std::endl;
+  std::cout << std::endl;
+#endif
 
   return computed_data;
 }

--- a/dedisp/cpp/src/fddplan.cpp
+++ b/dedisp/cpp/src/fddplan.cpp
@@ -221,10 +221,6 @@ xt::xarray<float> FDDPlan::execute(const xt::xarray<uint8_t> &input) {
 
 #ifdef DEDISP_BENCHMARK
   output_timer->pause();
-  // total_timer->pause();
-
-  // Print timings
-  // std::cout << "FDDPlan::execute() runtime:" << std::endl;
   std::cout << std::endl;
   std::cout << "Initialization time : " << init_timer->duration() << " sec."
             << std::endl;

--- a/dedisp/cpp/src/kernels.cpp
+++ b/dedisp/cpp/src/kernels.cpp
@@ -14,7 +14,9 @@ void fourier_domain_dedisperse(size_t dm_count, size_t n_frequencies,
                                size_t stride_in, size_t stride_out,
                                std::complex<float> *input,
                                std::complex<float> *output) {
+#ifdef DEDISP_USE_OPENMP
 #pragma omp parallel for
+#endif
   for (size_t dm_index = 0; dm_index < dm_count; ++dm_index) {
     // Calculate DM delays
     float dm_delays[n_channels];
@@ -34,10 +36,10 @@ void fourier_domain_dedisperse(size_t dm_count, size_t n_frequencies,
       for (size_t channel_index = 0; channel_index < n_channels;
            ++channel_index) {
         // Compute phasor
-        float phase = 2.0f * std::numbers::pi_v<float> *
+        const float phase = 2.0f * std::numbers::pi_v<float> *
                       spin_frequencies[frequency_index] *
                       dm_delays[channel_index];
-        std::complex<float> phasor{std::cos(phase), std::sin(phase)};
+        std::complex<float> phasor{std::cosf(phase), std::sinf(phase)};
 
         // Load sample
         std::complex<float> *sample_ptr = &input[channel_index * stride_in];

--- a/dedisp/cpp/src/kernels.cpp
+++ b/dedisp/cpp/src/kernels.cpp
@@ -37,8 +37,8 @@ void fourier_domain_dedisperse(size_t dm_count, size_t n_frequencies,
            ++channel_index) {
         // Compute phasor
         const float phase = 2.0f * std::numbers::pi_v<float> *
-                      spin_frequencies[frequency_index] *
-                      dm_delays[channel_index];
+                            spin_frequencies[frequency_index] *
+                            dm_delays[channel_index];
         std::complex<float> phasor{std::cosf(phase), std::sinf(phase)};
 
         // Load sample


### PR DESCRIPTION
This MR relates to #58, with the goal of bringing the execution time of the dedispersion kernel down to 1.5-2 seconds. Here we specifically use the `testfdd` binary as a benchmark.

Some improvements in no particular order:

- Using `std::cosf()` and `std::sinf()` instead of `std::cos()` and `std::sin`, which seems to speed-up the kernel by around 0.5 seconds. 

Other additions:

- A CMake flag to enable/disable OpenMP for debugging / benchmarking purposes.
- A CMake flag to enable/disable granular benchmarks in `FDDPlan::execute()`