### PR TITLE
feat: example benchmark for idg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ coverage.xml
 .venv
 dist
 __pycache__
+
+# Bencher
+results.json

--- a/idg/python/pyproject.toml
+++ b/idg/python/pyproject.toml
@@ -29,9 +29,7 @@ homepage = "https://github.com/astron-rd/pace"
 idg = "idg_python.main:main"
 
 [build-system]
-requires = [
-    "setuptools>=70.0"
-]
+requires = ["setuptools>=70.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages]
@@ -61,13 +59,12 @@ branch = true
 [tool.pytest.ini_options]
 env = [{"PYTHONWARNINGS"="default::DeprecationWarning"}]
 addopts = "--cov-report term --cov-report xml --cov-report html --cov=idg_python"
-testpaths = [
-    "tests",
-]
+testpaths = ["tests"]
 
 [dependency-groups]
 dev = [
+    "build>=0.8.0",
     "pytest>=7.0.0",
     "pytest-cov>=3.0.0",
-    "build>=0.8.0"
+    "pytest-benchmark>=5.2.3",
 ]

--- a/idg/python/tests/bench_kernels.py
+++ b/idg/python/tests/bench_kernels.py
@@ -1,0 +1,10 @@
+"""Benchmark tests for IDG Python kernels"""
+
+import numpy as np
+
+from idg_python.kernels.numba import evaluate_spheroidal
+
+
+def test_evaluate_spheroidal(benchmark):
+    nu = np.linspace(0.0, 1.0, 1024)
+    benchmark(evaluate_spheroidal, nu)

--- a/idg/python/tests/bench_kernels.py
+++ b/idg/python/tests/bench_kernels.py
@@ -7,4 +7,4 @@ from idg_python.kernels.numba import evaluate_spheroidal
 
 def test_evaluate_spheroidal(benchmark):
     nu = np.linspace(0.0, 1.0, 1024)
-    benchmark(evaluate_spheroidal, nu)
+    benchmark.pedantic(evaluate_spheroidal, args=(nu,), warmup_rounds=1)


### PR DESCRIPTION
I am experimenting with `bencher.dev` this PR adds an example benchmark to `idg/python`
- on purpose excluded from the test suite by using a filename that does not start with `test_`