### PR TITLE
feat: skip benchmarks in ci and enable warmup

### DIFF
--- a/idg/python/pyproject.toml
+++ b/idg/python/pyproject.toml
@@ -58,7 +58,7 @@ branch = true
 
 [tool.pytest.ini_options]
 env = [{"PYTHONWARNINGS"="default::DeprecationWarning"}]
-addopts = "--cov-report term --cov-report xml --cov-report html --cov=idg_python"
+addopts = "--cov-report term --cov-report xml --cov-report html --cov=idg_python --benchmark-skip --benchmark-warmup on"
 testpaths = ["tests"]
 
 [dependency-groups]

--- a/idg/python/tests/test_kernels.py
+++ b/idg/python/tests/test_kernels.py
@@ -7,4 +7,4 @@ from idg_python.kernels.numba import evaluate_spheroidal
 
 def test_evaluate_spheroidal(benchmark):
     nu = np.linspace(0.0, 1.0, 1024)
-    benchmark.pedantic(evaluate_spheroidal, args=(nu,), warmup_rounds=1)
+    benchmark(evaluate_spheroidal, nu)


### PR DESCRIPTION
- enables warmup globally for idg/python
- skips benchmarks in ci