### PR TITLE
fix: keep to the hdf5 input naming convention

### DIFF
--- a/idg/input/src/main.py
+++ b/idg/input/src/main.py
@@ -33,7 +33,7 @@ def main():
     )
 
     output_file = h5py.File("inputs.h5", "w")
-    output_file.create_dataset("uvw", data=uvw)
+    output_file.create_dataset("uvws", data=uvw)
     output_file.create_dataset("frequencies", data=frequencies)
     output_file.create_dataset("metadata", data=metadata)
     output_file.create_dataset("visibilities", data=visibilities)

--- a/idg/python/idg_python/main.py
+++ b/idg/python/idg_python/main.py
@@ -115,7 +115,7 @@ def main():
     if LOAD_INPUT is not None:
         print_header("READING INPUT DATA")
         with h5py.File(LOAD_INPUT, "r") as infile:
-            uvw_ds = infile["uvw"]
+            uvw_ds = infile["uvws"]
             if not isinstance(uvw_ds, h5py.Dataset):
                 print("Invalid input file: uvw is not defined")
                 return


### PR DESCRIPTION
The dataset containing the `uvw` data is called `uvws`, in keeping with the naming convention.