### PR TITLE
fix inconsistencies between input generator and rust idg

### DIFF
--- a/idg/rust/src/gridder.rs
+++ b/idg/rust/src/gridder.rs
@@ -197,7 +197,7 @@ fn visibility_to_subgrid(
             let n = compute_n(l, m);
 
             let pixels = compute_pixels(
-                metadata.timestep_count,
+                metadata.nr_timesteps,
                 metadata.time_index,
                 uvw,
                 metadata.baseline,
@@ -241,18 +241,18 @@ fn compute_n(l: Float, m: Float) -> Float {
 }
 
 fn compute_pixels(
-    timestep_count: u32,
-    offset: u32,
+    timestep_count: i32,
+    offset: i32,
     uvw: &UvwArray,
-    baseline: u32,
+    baseline: i32,
     l: Float,
     m: Float,
     n: Float,
     u_offset: Float,
     v_offset: Float,
     w_offset: Float,
-    channel_begin: u32,
-    channel_end: u32,
+    channel_begin: i32,
+    channel_end: i32,
     correlation_count_in: u32,
     correlation_count_out: u32,
     wavenumbers: &Array1<Float>,
@@ -302,8 +302,8 @@ fn add_subgrid_to_grid(
     let subgrid_size = subgrid.shape()[1];
     let correlation_count = subgrid.shape()[0];
 
-    assert!(metadata.coordinate.x < (grid_size - subgrid_size) as u32);
-    assert!(metadata.coordinate.y < (grid_size - subgrid_size) as u32);
+    assert!(metadata.coordinate.x < (grid_size - subgrid_size) as i32);
+    assert!(metadata.coordinate.y < (grid_size - subgrid_size) as i32);
 
     for y in 0..subgrid_size {
         for x in 0..subgrid_size {

--- a/idg/rust/src/types/metadata.rs
+++ b/idg/rust/src/types/metadata.rs
@@ -6,20 +6,20 @@ use ndarray::prelude::*;
 #[derive(Debug, PartialEq, Eq, H5Type)]
 #[repr(C)]
 pub struct Metadata {
-    pub baseline: u32,
-    pub time_index: u32,
-    pub timestep_count: u32,
-    pub channel_begin: u32,
-    pub channel_end: u32,
+    pub baseline: i32,
+    pub time_index: i32,
+    pub nr_timesteps: i32,
+    pub channel_begin: i32,
+    pub channel_end: i32,
     pub coordinate: Coordinate,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, H5Type)]
 #[repr(C)]
 pub struct Coordinate {
-    pub x: u32,
-    pub y: u32,
-    pub z: u32,
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
 }
 
 pub type MetadataArray = Array1<Metadata>;
@@ -75,7 +75,7 @@ fn compute_metadata(
     grid_size: u32,
     subgrid_size: u32,
     channel_count: u32,
-    baseline: u32,
+    baseline: i32,
     u_pixels: &ArrayView1<Float>,
     v_pixels: &ArrayView1<Float>,
     max_group_size: u32,
@@ -111,25 +111,25 @@ fn compute_metadata(
             .mean()
             .expect("This slice should not be empty");
 
-        let subgrid_x = (group_u as u32)
-            .checked_sub(subgrid_size / 2)
+        let subgrid_x = (group_u as i32)
+            .checked_sub(subgrid_size as i32 / 2)
             .expect("shouldn't underflow");
-        let subgrid_y = (group_v as u32)
-            .checked_sub(subgrid_size / 2)
+        let subgrid_y = (group_v as i32)
+            .checked_sub(subgrid_size as i32 / 2)
             .expect("shouldn't underflow");
         assert!(
             subgrid_size <= grid_size,
             "subgrid shouldn't be larger than grid"
         );
-        let subgrid_x = subgrid_x.clamp(0, grid_size - subgrid_size);
-        let subgrid_y = subgrid_y.clamp(0, grid_size - subgrid_size);
+        let subgrid_x = subgrid_x.clamp(0, (grid_size - subgrid_size) as i32);
+        let subgrid_y = subgrid_y.clamp(0, (grid_size - subgrid_size) as i32);
 
         metadata.push(Metadata {
             baseline,
             time_index: timestep.try_into().unwrap(),
-            timestep_count: group_size.try_into().unwrap(),
+            nr_timesteps: group_size.try_into().unwrap(),
             channel_begin: 0,
-            channel_end: channel_count,
+            channel_end: channel_count.try_into().unwrap(),
             coordinate: Coordinate {
                 x: subgrid_x,
                 y: subgrid_y,


### PR DESCRIPTION
There were some inconsistencies between the input generated by the input generator and the Rust version of IDG. This led the Rust version to not function correctly with input generated by the input generator.